### PR TITLE
Fix silent invalid selection bug in menu

### DIFF
--- a/scripts/interface.py
+++ b/scripts/interface.py
@@ -92,7 +92,7 @@ def menu_select():
         elif selection.lower() == "x":
             break
         else:
-            "Invalid selection."
+            print("Invalid selection.")
         print("\n", end="")
 
 


### PR DESCRIPTION
Changed line 95 from a dangling string literal to an actual print statement. Users will now see "Invalid selection." when entering invalid menu options. (Kaleb note: this is an early experiment with Claude Code)