### PR TITLE
Add error handling for missing or invalid config.toml

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -24,8 +24,22 @@ def get_config():
     config_path = os.path.join(os.path.dirname(__file__), 'config.toml')
     config_path = os.path.abspath(config_path)
 
-    with open(config_path, "rb") as cfg:
-        config = tomllib.load(cfg)
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(
+            f"Configuration file not found at: {config_path}\n"
+            f"Please create a config.toml file with MongoDB connection settings.\n"
+            f"See README.md for configuration instructions."
+        )
+
+    try:
+        with open(config_path, "rb") as cfg:
+            config = tomllib.load(cfg)
+    except tomllib.TOMLDecodeError as e:
+        raise ValueError(
+            f"Invalid TOML syntax in config file: {config_path}\n"
+            f"Error: {e}"
+        )
+
     return config
 
 


### PR DESCRIPTION
Added checks in get_config() to:
- Verify config.toml exists before attempting to open
- Catch TOML syntax errors with clear error messages
- Provide helpful guidance on how to fix the issue

This prevents cryptic crashes at module import time when the configuration file is missing or malformed.

(Kaleb note: early test of Claude)