### PR TITLE
Improve exception messages for better debugging and stability

### DIFF
--- a/scripts/Australia/retrieve.py
+++ b/scripts/Australia/retrieve.py
@@ -35,7 +35,7 @@ def retrieve_data(folder):
         response_df = pd.read_csv(api_retrieval_point, encoding_errors="backslashreplace")
         response_df.to_csv(f"{folder}cache.csv")
     else:
-        raise Exception
+        raise Exception(f"Unexpected cache state: cached={cached}. Expected True or False.")
 
     # Structure
     print(" Step 2 of 2: Structuring data as dicts".ljust(50), end="\n")

--- a/scripts/NewZealand/retrieve.py
+++ b/scripts/NewZealand/retrieve.py
@@ -30,7 +30,7 @@ def retrieve_data(folder):
         response_df = pd.read_csv(response_text, low_memory=False)
         response_df.to_csv(f"{folder}cache.csv")
     else:
-        raise Exception
+        raise Exception(f"Unexpected cache state: cached={cached}. Expected True or False.")
 
     # Structure
     print(f" Step 4 of 4: Structuring data as dicts".ljust(50), end="\n")

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -158,9 +158,9 @@ def meta_check(registry_name, source_url, collection="organizations"):
         decision = delete_old_records(result['_id'], collection)
         return result['_id'], decision
     elif preexisting_registries >= 2:
-        raise Exception("Too many")
+        raise Exception(f"Database integrity error: Found {preexisting_registries} registries with name '{registry_name}'. Expected 0 or 1.")
     else:
-        raise Exception("Something weird")
+        raise Exception(f"Unexpected database state: Registry count for '{registry_name}' is {preexisting_registries}. This should not be possible.")
 
 
 def retrieve_mapping(folder=""):
@@ -331,9 +331,9 @@ def match_filing(filing, matching_field='entityId', auto_create_from_orphan=True
             if manual_decision == "y":
                 entity_id_mongo = create_organization_from_orphan_filing(filing)
             else:
-                raise Exception("No matching orgs found")
+                raise Exception(f"No matching organization found for filing with {matching_field}='{entity_id}' in registry '{registry_id}'. User declined to create orphan organization.")
     elif len(matched_orgs) >= 2:
-        raise Exception
+        raise Exception(f"Database integrity error: Found {len(matched_orgs)} organizations matching {matching_field}='{entity_id}' in registry '{registry_id}'. Expected 0 or 1. Filing ID: {filing.get('_id', 'unknown')}")
     elif len(matched_orgs) == 1:
         [matched_org] = matched_orgs
         entity_id_mongo = matched_org['_id']


### PR DESCRIPTION
Replaced vague or missing error messages with descriptive exceptions that include:
- Specific context about what went wrong
- Variable values that caused the error
- Expected vs actual states
- Related entity/filing IDs for tracing issues

This improves stability by making it much easier to diagnose problems during bulk operations (e.g., matching 500k+ filings) and database integrity issues.

Changes:
- utils.py: Enhanced 4 exception messages in meta_check() and match_filing()
- Australia/retrieve.py: Added descriptive message for cache state error
- NewZealand/retrieve.py: Added descriptive message for cache state error