### PR TITLE
Optimize status_check() with aggregation pipeline to reduce database …

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -211,9 +211,21 @@ def status_check():
 
     registries = list_registries()
 
+    # Optimized: Use aggregation pipeline to get counts for all registries in 2 queries instead of 2*N queries
+    print("  Aggregating counts by registry...", end="")
+    org_counts_cursor = mongo_regeindary[orgs].aggregate([
+        {"$group": {"_id": "$registryID", "count": {"$sum": 1}}}
+    ])
+    org_counts = {doc['_id']: doc['count'] for doc in org_counts_cursor}
+
+    filing_counts_cursor = mongo_regeindary[filings].aggregate([
+        {"$group": {"_id": "$registryID", "count": {"$sum": 1}}}
+    ])
+    filing_counts = {doc['_id']: doc['count'] for doc in filing_counts_cursor}
+    print(" ✔")
+
     print(n_registries, "registries,", n_organizations, "organizations, and", n_filings, "filings")
     for registry in registries:
-        # - [ ] consider replacing with a pipeline
         print(registry['name'].ljust(80, "."), end="")
 
         completion_time = registry.get("download_completion", False)
@@ -223,12 +235,13 @@ def status_check():
             completion_time = "NOT COMPLETED YET"
         print(completion_time, end="...................")
 
-        n_orgs_in_registry = mongo_regeindary[orgs].count_documents({'registryID': registry['_id']})
-        fraction = n_orgs_in_registry / n_organizations
+        # Use pre-computed counts from aggregation instead of individual queries
+        n_orgs_in_registry = org_counts.get(registry['_id'], 0)
+        fraction = n_orgs_in_registry / n_organizations if n_organizations > 0 else 0
         percentage = round(fraction * 100, 2)
         percentage = f"{percentage}%"
         print(f"{n_orgs_in_registry} orgs ({percentage})".ljust(10), end="")
-        n_filings_in_registry = mongo_regeindary[filings].count_documents({'registryID': registry['_id']})
+        n_filings_in_registry = filing_counts.get(registry['_id'], 0)
         print(f" & {n_filings_in_registry} filings".ljust(30))
 
     total_size = mongo_regeindary.command("dbstats")['totalSize']


### PR DESCRIPTION
…queries

- Replaced 2*N count_documents() queries with 2 aggregation queries
- For 4 registries: 8 queries → 2 queries (75% reduction)
- Pre-compute counts for all registries using $group aggregation
- Added division by zero protection
- Resolves TODO comment about using pipeline