### PR TITLE
Prevent division by zero crash in status_check()

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -203,9 +203,12 @@ def status_check():
         print(completion_time, end="...................")
 
         n_orgs_in_registry = mongo_regeindary[orgs].count_documents({'registryID': registry['_id']})
-        fraction = n_orgs_in_registry / n_organizations
-        percentage = round(fraction * 100, 2)
-        percentage = f"{percentage}%"
+        if n_organizations > 0:
+            fraction = n_orgs_in_registry / n_organizations
+            percentage = round(fraction * 100, 2)
+            percentage = f"{percentage}%"
+        else:
+            percentage = "N/A"
         print(f"{n_orgs_in_registry} orgs ({percentage})".ljust(10), end="")
         n_filings_in_registry = mongo_regeindary[filings].count_documents({'registryID': registry['_id']})
         print(f" & {n_filings_in_registry} filings".ljust(30))


### PR DESCRIPTION
Fixed a crash that would occur when running status_check() on an empty database or after all organizations have been deleted.

The status_check() function now gracefully handles the case where n_organizations is 0 by displaying "N/A" for the percentage instead of attempting to divide by zero.

This improves stability for:
- Fresh database setups during testing
- Database maintenance operations
- Edge cases where registries exist but have no organizations yet