### PR TITLE
Add support for Ireland Charities Regulator registry

### DIFF
--- a/scripts/Ireland/README.md
+++ b/scripts/Ireland/README.md
@@ -1,0 +1,124 @@
+# Ireland - Charities Regulator
+
+## Data Source
+
+**Source URL**: https://data.gov.ie/dataset/register-of-charities-in-ireland
+**Registry**: Charities Regulator (Ireland)
+**License**: Creative Commons Attribution 4.0 International (CC-BY 4.0)
+
+## Data Files
+
+This module retrieves two datasets:
+
+1. **Entities** (Register of Charities):
+   https://www.charitiesregulator.ie/media/d52jwriz/register-of-charities.csv
+
+2. **Filings** (Annual Reports):
+   https://www.charitiesregulator.ie/media/yeia3rfc/charity-annual-reports.csv
+
+## Setup Instructions
+
+### Step 1: Verify Field Mappings
+
+The `mapping.json` file contains placeholder field names that need to be verified and updated based on the actual CSV column names.
+
+To check the actual column names:
+
+```python
+import pandas as pd
+
+# Check entities columns
+df_entities = pd.read_csv('https://www.charitiesregulator.ie/media/d52jwriz/register-of-charities.csv')
+print("Entity columns:")
+print(df_entities.columns.tolist())
+
+# Check filings columns
+df_filings = pd.read_csv('https://www.charitiesregulator.ie/media/yeia3rfc/charity-annual-reports.csv')
+print("\nFiling columns:")
+print(df_filings.columns.tolist())
+```
+
+### Step 2: Update mapping.json
+
+Once you know the actual column names, update `mapping.json` to map the source fields to the standardized schema fields.
+
+**Entity field mappings** (target fields from `schemas/entity.json`):
+- `entityName` - Organization name
+- `entityId` - Charity registration number
+- `registeredDate` - Date registered with regulator
+- `websiteUrl` - Organization website
+- `establishedDate` - Date organization was established
+
+**Filing field mappings** (target fields from `schemas/filing.json`):
+- `entityId` - Charity number (links to entity)
+- `startDate` - Financial period start date
+- `endDate` - Financial period end date
+- `recordDate` - Date the filing was received
+- `totalIncome` - Total income for the period
+- `totalExpenditures` - Total expenditures for the period
+
+### Step 3: Date Format Handling
+
+If the CSV uses a date format other than YYYY-MM-DD, add a `"format"` key to the mapping:
+
+```json
+{
+  "origin": "Registration Date",
+  "target": "registeredDate",
+  "format": "DD/MM/YYYY"
+}
+```
+
+Common formats:
+- `DD/MM/YYYY` - e.g., 25/12/2020
+- `MM/DD/YYYY` - e.g., 12/25/2020
+- `YYYY-MM-DD` - e.g., 2020-12-25 (ISO format, no format key needed)
+
+## Running the Import
+
+Once the mapping is verified:
+
+```bash
+cd /home/user/regeindary/scripts
+python interface.py
+```
+
+Select option `[2] Retrieve Registries`, then choose `[3] Ireland`.
+
+## Troubleshooting
+
+### Download Errors
+
+If you encounter download errors (e.g., Cloudflare protection), the website may be blocking automated requests. Try:
+
+1. Manually download the CSV files from the URLs above
+2. Place them in `/home/user/regeindary/scripts/Ireland/` as:
+   - `cache_entities.csv`
+   - `cache_filings.csv`
+3. Run the import - it will use the cached files
+
+### Field Mapping Issues
+
+After import, use the built-in tools to verify data quality:
+
+```
+[1] Run Status Check - See how many records were imported
+[3] Keyword Match Assist - Check which fields are mapped
+[5] Display Random Entity - Inspect actual data
+```
+
+### Missing Fields
+
+Not all fields need to be mapped. Unmapped fields are preserved in the "Original Data" section of each MongoDB document.
+
+## Notes
+
+- **Update Frequency**: The register is updated weekly according to data.gov.ie
+- **Data Coverage**: Includes all registered charities in Ireland
+- **Filings**: Annual reports filed with the Charities Regulator
+
+## References
+
+- [Charities Regulator Website](https://www.charitiesregulator.ie/en)
+- [Data Portal](https://data.gov.ie/dataset/register-of-charities-in-ireland)
+- [CC-BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)

--- a/scripts/Ireland/mapping.json
+++ b/scripts/Ireland/mapping.json
@@ -1,0 +1,48 @@
+[
+  {
+    "_comment": "Entity mappings - Update field names after examining actual CSV columns",
+    "origin": "Charity Name",
+    "target": "entityName"
+  },
+  {
+    "origin": "Registered Charity Number",
+    "target": "entityId"
+  },
+  {
+    "origin": "Registration Date",
+    "target": "registeredDate",
+    "format": "YYYY-MM-DD"
+  },
+  {
+    "origin": "Website",
+    "target": "websiteUrl"
+  },
+  {
+    "_comment": "Filing mappings - Update field names after examining actual CSV columns",
+    "origin": "Charity Number",
+    "target": "entityId"
+  },
+  {
+    "origin": "Financial Period Start",
+    "target": "startDate",
+    "format": "YYYY-MM-DD"
+  },
+  {
+    "origin": "Financial Period End",
+    "target": "endDate",
+    "format": "YYYY-MM-DD"
+  },
+  {
+    "origin": "Date Filed",
+    "target": "recordDate",
+    "format": "YYYY-MM-DD"
+  },
+  {
+    "origin": "Total Income",
+    "target": "totalIncome"
+  },
+  {
+    "origin": "Total Expenditure",
+    "target": "totalExpenditures"
+  }
+]

--- a/scripts/Ireland/retrieve.py
+++ b/scripts/Ireland/retrieve.py
@@ -1,0 +1,162 @@
+"""Data retrieval module for Ireland charity registry.
+
+Downloads charity entities and filing data from the Charities Regulator,
+applies field mappings according to mapping.json, and uploads to MongoDB.
+"""
+from scripts.utils import *
+from requests import get
+import pandas as pd
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Globals
+api_retrieval_points = {
+    "entities": "https://www.charitiesregulator.ie/media/d52jwriz/register-of-charities.csv",
+    "filings": "https://www.charitiesregulator.ie/media/yeia3rfc/charity-annual-reports.csv"
+}
+source_url = 'https://data.gov.ie/dataset/register-of-charities-in-ireland'
+headers = {"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"}
+registry_name = "Ireland - Charities Regulator"
+
+
+def retrieve_data(folder, label):
+    """Download and parse Ireland charity data (entities or filings).
+
+    Args:
+        folder (str): Directory path for cache storage.
+        label (str): Dataset type - either "entities" or "filings".
+
+    Returns:
+        list: List of dictionaries containing charity or filing records.
+    """
+    cached = check_for_cache(folder, label=label, suffix="csv")
+
+    logger.info(f"Retrieving '{label}' dataset")
+
+    if cached:
+        logger.info("Loading data from cache")
+    elif cached is False:
+        logger.info(f"Downloading {label} data from Charities Regulator")
+        print(f"  Step 1: Downloading {label} data...")
+        download_csv(folder, label)
+
+    logger.info(f"Loading CSV data from cache_{label}.csv")
+    print(f"  Step 2: Loading CSV data...")
+    response_df = pd.read_csv(f"{folder}cache_{label}.csv", low_memory=False)
+
+    logger.info(f"Converting {len(response_df):,} records to dictionary format")
+    response_dicts = response_df.to_dict(orient="records")
+
+    logger.info(f"Loaded {len(response_dicts):,} {label} records")
+    return response_dicts
+
+
+def download_csv(folder, label):
+    """Download CSV data from Charities Regulator.
+
+    Args:
+        folder (str): Directory path for cache storage.
+        label (str): Dataset type - either "entities" or "filings".
+
+    Raises:
+        Exception: If HTTP status code is not 200.
+    """
+    api_retrieval_point = api_retrieval_points[label]
+
+    logger.info(f"Downloading from {api_retrieval_point}")
+    response = get(api_retrieval_point, headers=headers)
+
+    if (sc := response.status_code) != 200:
+        logger.error(f"HTTP request failed with status code {sc}")
+        raise Exception(f"Actual Status Code {str(sc)} ≠ Expected Status Code 200")
+
+    logger.debug(f"Saving CSV data to cache_{label}.csv")
+    with open(f"{folder}cache_{label}.csv", 'wb') as csv_file:
+        csv_file.write(response.content)
+
+    logger.info("Download complete")
+
+
+def run_everything(folder=""):
+    """Main orchestration function for retrieving Ireland charity data.
+
+    Processes both entities (charities) and filings (annual reports) from the
+    Charities Regulator. Applies field mappings and uploads to MongoDB.
+
+    Args:
+        folder (str): Directory path for cache and mapping files. Defaults to "".
+
+    Returns:
+        dict or None: Dictionary of MongoDB insert results, or None if user skips upload.
+    """
+    # Initiation Message
+    logger.info(f"========== Starting {registry_name} data retrieval ==========")
+    print(f"\n{'='*70}")
+    print(f"Retrieving data from: {registry_name}")
+    print(f"{'='*70}\n")
+
+    # Legal Notice
+    description = ("You are free to:\n"
+                   "Share — copy and redistribute the material in any medium or format for any purpose, "
+                   "even commercially.\n"
+                   "Adapt — remix, transform, and build upon the material for any purpose, even commercially.\n"
+                   "The licensor cannot revoke these freedoms as long as you follow the license terms.\n"
+                   "Under the following terms:\n"
+                   "Attribution — You must give appropriate credit , provide a link to the license, and "
+                   "indicate if changes were made. You may do so in any reasonable manner, but not in any way "
+                   "that suggests the licensor endorses you or your use.\n"
+                   "ShareAlike — If you remix, transform, or build upon the material, you must distribute "
+                   "your contributions under the same license as the original.\n"
+                   "No additional restrictions — You may not apply legal terms or technological measures that "
+                   "legally restrict others from doing anything the license permits.")
+
+    legal_notice = {
+        "title": "Creative Commons Attribution 4.0 International",
+        "description": description,
+        "url": "https://creativecommons.org/licenses/by/4.0/"
+    }
+
+    # Entities
+    logger.info("Phase 1: Processing charity entities")
+    print("Phase 1: Processing Charity Entities")
+    print("-" * 70)
+    raw_dicts = retrieve_data(folder, label="entities")
+    custom_mapping = retrieve_mapping(folder)
+    meta_id, skip = meta_check(registry_name, source_url)
+
+    # Upload Data
+    static_amendment = {
+        "legalNotices": [legal_notice],
+        "registryName": registry_name,
+        "registryID": meta_id
+    }
+
+    logger.info(f"Retrieved {len(raw_dicts):,} entity records")
+    print(f"  Retrieved {len(raw_dicts):,} entity records\n")
+    final_results = None
+    if skip != 's':
+        final_results = send_all_to_mongodb(raw_dicts, custom_mapping, static_amendment)
+
+    # Filings
+    logger.info("Phase 2: Processing charity filings")
+    print(f"\n{'='*70}")
+    print("Phase 2: Processing Charity Filings (Annual Reports)")
+    print("-" * 70)
+    raw_dicts = retrieve_data(folder, label="filings")
+    meta_id, skip = meta_check(registry_name, source_url, collection="filings")
+
+    logger.info(f"Retrieved {len(raw_dicts):,} filing records")
+    print(f"  Retrieved {len(raw_dicts):,} filing records\n")
+    if skip != 's':
+        final_results = send_all_to_mongodb(raw_dicts, custom_mapping, static_amendment, collection='filings')
+
+    completion_timestamp(meta_id)
+    logger.info(f"✔ {registry_name} data retrieval completed successfully")
+    print("\n✔ Ireland import complete\n")
+    return final_results
+
+
+if __name__ == '__main__':
+    run_everything()

--- a/scripts/interface.py
+++ b/scripts/interface.py
@@ -27,22 +27,24 @@ def retrieve_registries():
     Options:
         [1] Australia
         [2] England and Wales
-        [3] New Zealand
-        [4] United States
+        [3] Ireland
+        [4] New Zealand
+        [5] United States
         [A] Run All
         [X] Exit
     """
     retrieval_options = """[1] Australia
 [2] England and Wales
-[3] New Zealand
-[4] United States
+[3] Ireland
+[4] New Zealand
+[5] United States
 [A] Run All
 [X] Exit"""
 
     print(retrieval_options)
 
     selection = input("Choose option(s), comma separate if multiple: ")
-    all_options = [str(x) for x in range(1, 5)] # - [ ] make sure this updates when adding a country
+    all_options = [str(x) for x in range(1, 6)] # - [ ] make sure this updates when adding a country
     if selection == "A":
         selection = all_options
         logger.info(f"Running all registry imports: {selection}")
@@ -67,10 +69,14 @@ def retrieve_registries():
             import scripts.EnglandWales.retrieve as engwal
             engwal.run_everything("EnglandWales/")
         elif s == "3":
+            logger.info("Starting Ireland registry import")
+            import scripts.Ireland.retrieve as ireland
+            ireland.run_everything("Ireland/")
+        elif s == "4":
             logger.info("Starting New Zealand registry import")
             import scripts.NewZealand.retrieve as newzee
             newzee.run_everything("NewZealand/")
-        elif s == "4":
+        elif s == "5":
             logger.info("Starting United States registry import")
             import scripts.UnitedStates.retrieve as ustates
             ustates.run_everything("United States/")


### PR DESCRIPTION
- Created Ireland/retrieve.py following standard pattern
- Handles both entities and filings datasets
- Added mapping.json with placeholder field names
- Updated interface.py to include Ireland as option [3]
- Renumbered New Zealand to [4] and United States to [5]
- Included README with setup instructions for verifying field mappings
- Data source: https://data.gov.ie/dataset/register-of-charities-in-ireland
- License: Creative Commons Attribution 4.0 International